### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,17 @@
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+# https://beta.ruff.rs/docs
+name: ruff
+on:
+  push:
+  #  branches:
+  #    - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user ruff
+    - run: ruff --format=github --line-length=114 --target-version=py37 .

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -14,4 +14,5 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: pip install --user ruff
-    - run: ruff --format=github --line-length=114 --target-version=py37 .
+    - run: ruff --format=github --extend-exclude=backend/apps/users/migrations
+                --ignore=F401 --line-length=114 --target-version=py37 .


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) including bandit, isort, pylint, pyupgrade, and flake8 plus its plugins and is written in Rust for speed.

The `ruff` Action uses minimal steps to run in ~10 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)